### PR TITLE
Ft login screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "jest --runInBand --verbose --detectOpenHandles --forceExit",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "test:coverage": "yarn test --coverage",
-    "report-coverage": "coveralls < ./coverage/lcov.info",
-    "preinstall": "rm -rf .git/hooks/pre-push && rm -rf .git/hooks/pre-commit"
+    "report-coverage": "coveralls < ./coverage/lcov.info"
   },
   "dependencies": {
     "@expo/vector-icons": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-native-app-intro-slider": "^3.0.0",
     "react-native-dotenv": "^0.2.0",
     "react-native-gesture-handler": "~1.5.0",
+    "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
     "react-native-svg": "9.13.3",

--- a/src/__test__/config/jest.setup.ts
+++ b/src/__test__/config/jest.setup.ts
@@ -1,3 +1,5 @@
 import { cleanup } from '@testing-library/react-native';
 
+afterEach(cleanup);
+
 afterAll(cleanup);

--- a/src/__test__/screens/signin/index.test.tsx
+++ b/src/__test__/screens/signin/index.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import Theme from '../../../theme';
+import { createNavigationTestProps } from '../../../constants';
+import SignInScreen from '../../../screens/signin';
+
+const mountComponent = () => {
+  const props: any = createNavigationTestProps();
+  const renderedProps = render(
+    <Theme>
+      <SignInScreen {...props} />
+    </Theme>
+  );
+  return { props, ...renderedProps };
+};
+
+describe(' TEST SIGN_IN SCREEN (<SignInScreen/>)', () => {
+  test('It renders the App logo component', () => {
+    const { queryByTestId } = mountComponent();
+    expect(queryByTestId('appLogo')).toBeTruthy();
+  });
+
+  test('That the screen has all the necessary input fields', () => {
+    const { getByTestId } = mountComponent();
+    expect(getByTestId('email')).toBeTruthy();
+    expect(getByTestId('password')).toBeTruthy();
+  });
+
+  test('That the forgot password button was pressed', () => {
+    const { props, queryByTestId } = mountComponent();
+    const signUpButton = queryByTestId('resetAccount');
+    expect(signUpButton).toBeTruthy();
+    fireEvent.press(queryByTestId('resetAccount'));
+    expect(props.navigation.navigate).toHaveBeenCalledTimes(1);
+    expect(props.navigation.navigate).toHaveBeenCalledWith(
+      'ForgotPasswordScreen'
+    );
+  });
+
+  test('That the login button was pressed', () => {
+    const { props, queryByTestId } = mountComponent();
+    const loginButton = queryByTestId('loginButton');
+    expect(loginButton).toBeTruthy();
+    fireEvent.press(queryByTestId('loginButton'));
+    expect(props.navigation.replace).toHaveBeenCalledTimes(1);
+    expect(props.navigation.replace).toHaveBeenCalledWith('HomeScreen');
+  });
+
+  test('That the sigUp button was pressed', () => {
+    const { props, queryByTestId } = mountComponent();
+    const signUpButton = queryByTestId('createAccount');
+    expect(signUpButton).toBeTruthy();
+    fireEvent.press(queryByTestId('createAccount'));
+    expect(props.navigation.navigate).toHaveBeenCalledTimes(1);
+    expect(props.navigation.navigate).toHaveBeenCalledWith('SignUpScreen');
+  });
+});

--- a/src/__test__/screens/signup/index.test.tsx
+++ b/src/__test__/screens/signup/index.test.tsx
@@ -4,13 +4,6 @@ import Theme from '../../../theme';
 import { createNavigationTestProps } from '../../../constants';
 import SignUpScreen from '../../../screens/signup';
 
-const user = {
-  userName: 'user1',
-  email: 'user1@decagonhq.com',
-  phone: '+2347090231093',
-  password: 'password'
-};
-
 const mountComponent = () => {
   const onHandleChange = jest.fn(() => {});
 
@@ -47,7 +40,7 @@ describe(' TEST GET_SIGNUP SCREEN (<SignUpScreen/>)', () => {
     expect(loginButton).toBeTruthy();
     fireEvent.press(queryByTestId('loginButton'));
     expect(props.navigation.navigate).toHaveBeenCalledTimes(1);
-    expect(props.navigation.navigate).toHaveBeenCalledWith('LoginScreen');
+    expect(props.navigation.navigate).toHaveBeenCalledWith('SignInScreen');
   });
 
   test('That the sigUp button was pressed', () => {

--- a/src/__test__/screens/splash/index.test.tsx
+++ b/src/__test__/screens/splash/index.test.tsx
@@ -40,7 +40,7 @@ describe('TEST SPLASH COMPONENT(<SplashScreen/>)', () => {
     const { props } = mountComponent();
     act(() => jest.advanceTimersByTime(4000));
     expect(props.navigation.replace).toHaveBeenCalled();
-    expect(props.navigation.replace).toBeCalledWith('HomeScreen');
+    expect(props.navigation.replace).toBeCalledWith('SignInScreen');
     expect(props.navigation.replace).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,14 +4,6 @@ import {
   NavigationState
 } from 'react-navigation';
 
-// App header custom style
-export const customHeaderStyle = {
-  borderBottomWidth: 0,
-  elevation: 0,
-  shadowOpacity: 0,
-  backgroundColor: '#F4F8FB'
-};
-
 interface NavigationScreenType
   extends NavigationScreenProp<NavigationState, NavigationParams> {
   replace: (T: string) => void;
@@ -46,4 +38,25 @@ export const createNavigationTestProps = (props: object = {}) => ({
 export type IconProps = {
   width?: string;
   height?: string;
+};
+
+// App header custom style
+export const customHeaderStyle = {
+  borderBottomWidth: 0,
+  elevation: 0,
+  shadowOpacity: 0,
+  backgroundColor: '#F4F8FB'
+};
+
+// Navigation Header back button default
+export const navigationBackButton = {
+  headerBackTitle: 'back',
+  headerBackColor: '#0D0E10',
+  headerTintColor: '#0D0E10',
+  headerBackTitleStyle: {
+    color: '#0D0E10',
+    fontFamily: 'montserrat-semi-bold',
+    textTransform: 'capitalize',
+    fontSize: 12
+  }
 };

--- a/src/lib/BouncyCheckbox/index.js
+++ b/src/lib/BouncyCheckbox/index.js
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Animated, Easing, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import styles, { iconContainer, textStyle } from './styles';
+
+class BouncyCheckbox extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      checked: false,
+      springValue: new Animated.Value(1)
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ checked: this.props.isChecked });
+  }
+
+  spring = () => {
+    const { checked, springValue } = this.state;
+    this.setState({ checked: !checked }, () => {
+      springValue.setValue(0.7);
+      Animated.spring(springValue, {
+        toValue: 1,
+        friction: 3
+      }).start();
+      // Outside of the onPress function
+      const { onPress } = this.props;
+      if (onPress) onPress(this.state.checked);
+    });
+  };
+
+  renderCheckIcon = () => {
+    const { checked, springValue } = this.state;
+    const {
+      checkboxSize,
+      borderColor,
+      fillColor,
+      borderRadius,
+      unfillColor,
+      iconComponent
+    } = this.props;
+    return (
+      <Animated.View
+        style={[
+          iconContainer(
+            checkboxSize,
+            checked,
+            borderRadius,
+            borderColor,
+            fillColor,
+            unfillColor
+          ),
+          { transform: [{ scale: springValue }] }
+        ]}
+      >
+        {iconComponent ||
+          (this.state.checked ? (
+            <Ionicons
+              {...this.props}
+              name="ios-checkmark"
+              size={20}
+              color="white"
+            />
+          ) : null)}
+      </Animated.View>
+    );
+  };
+
+  render() {
+    const { text, textColor, fontFamily, fontSize } = this.props;
+
+    return (
+      <TouchableOpacity
+        style={styles.container}
+        onPress={this.spring.bind(this, Easing.bounce)}
+      >
+        {this.renderCheckIcon()}
+        <View style={styles.textContainer}>
+          <Text
+            style={textStyle(
+              this.state.checked,
+              textColor,
+              fontFamily,
+              fontSize
+            )}
+          >
+            {text}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+BouncyCheckbox.propTypes = {
+  text: PropTypes.string,
+  textColor: PropTypes.string,
+  fontFamily: PropTypes.string,
+  borderRadius: PropTypes.number,
+  fontSize: PropTypes.number,
+  isChecked: PropTypes.bool,
+  checkboxSize: PropTypes.number,
+  borderColor: PropTypes.string,
+  fillColor: PropTypes.string,
+  unfillColor: PropTypes.string,
+  iconComponent: PropTypes.elementType
+};
+
+BouncyCheckbox.defaultProps = {
+  fontSize: 16,
+  checkboxSize: 25,
+  borderRadius: 25 / 2,
+  isChecked: false,
+  text: 'Call my mom 😇',
+  textColor: '#757575',
+  fillColor: '#50AE7C',
+  borderColor: '#50AE7C',
+  unfillColor: 'transparent'
+};
+
+export default BouncyCheckbox;

--- a/src/lib/BouncyCheckbox/styles.js
+++ b/src/lib/BouncyCheckbox/styles.js
@@ -1,0 +1,36 @@
+export const iconContainer = (
+  size,
+  checked,
+  borderRadius,
+  borderColor,
+  fillColor,
+  unfillColor
+) => {
+  return {
+    width: size,
+    borderColor,
+    borderRadius,
+    height: size,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: checked ? fillColor : unfillColor
+  };
+};
+
+export const textStyle = (_checked, textColor, fontFamily, fontSize) => {
+  return {
+    fontFamily,
+    fontSize,
+    color: textColor
+  };
+};
+
+export default {
+  container: {
+    margin: 8,
+    alignItems: 'center',
+    flexDirection: 'row'
+  },
+  textContainer: { marginLeft: 10 }
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,6 @@
 import { createStackNavigator } from 'react-navigation-stack';
 import { createAppContainer } from 'react-navigation';
-import { customHeaderStyle } from './constants';
+import { customHeaderStyle, navigationBackButton } from './constants';
 
 import Screens from './screens';
 
@@ -18,14 +18,20 @@ const AppNavigator = createStackNavigator(
     // Sign Up Screen Route
     SignUpScreen: { screen: Screens.SignUpScreen },
 
+    // Sign In Screen Route
+    SignInScreen: { screen: Screens.SignInScreen },
+
     // Home Screen Route
     HomeScreen: { screen: Screens.HomeScreen }
   },
 
   {
-    initialRouteName: 'SplashScreen',
+    initialRouteName: 'SignInScreen',
     headerMode: 'screen',
-    defaultNavigationOptions: { headerStyle: customHeaderStyle }
+    defaultNavigationOptions: ({ navigation }) => {
+      navigation.state['navigationBackButton'] = navigationBackButton;
+      return { headerStyle: customHeaderStyle };
+    }
   }
 );
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,7 +26,7 @@ const AppNavigator = createStackNavigator(
   },
 
   {
-    initialRouteName: 'SignInScreen',
+    initialRouteName: 'SplashScreen',
     headerMode: 'screen',
     defaultNavigationOptions: ({ navigation }) => {
       navigation.state['navigationBackButton'] = navigationBackButton;

--- a/src/screens/forgot_password/index.tsx
+++ b/src/screens/forgot_password/index.tsx
@@ -97,6 +97,15 @@ export default function ForgotPasswordScreen({ navigation }: SplashScreenProp) {
   );
 }
 
-ForgotPasswordScreen.navigationOptions = {
-  headerTitle: () => <HeaderTitle>forgot password</HeaderTitle>
+ForgotPasswordScreen.navigationOptions = ({
+  navigation,
+  navigationOptions
+}) => {
+  const { navigationBackButton } = navigation.state;
+
+  return {
+    ...navigationOptions,
+    ...navigationBackButton,
+    headerTitle: () => <HeaderTitle>forgot password</HeaderTitle>
+  };
 };

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -2,10 +2,12 @@ import HomeScreen from './home';
 import SplashScreen from './splash';
 import GetStartedScreen from './get_started';
 import SignUpScreen from './signup';
+import SignInScreen from './signin';
 import ForgotPasswordScreen from './forgot_password';
 
 export default {
   SignUpScreen,
+  SignInScreen,
   HomeScreen,
   SplashScreen,
   GetStartedScreen,

--- a/src/screens/signin/index.tsx
+++ b/src/screens/signin/index.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import BouncyCheckbox from '../../lib/BouncyCheckbox';
+import { useThemeContext } from '../../theme';
+import { NavigationInterface } from '../../constants';
+
+import Button from '../../components/button';
+import InputFiled from '../../components/inputField';
+
+import MailIcon from '../../../assets/icons/mail';
+import PrivacyIcon from '../../../assets/icons/privacy';
+import boxShadow from '../../utils/boxShadows';
+
+import {
+  Container,
+  Logo,
+  FormFields,
+  FormControls,
+  Conditions,
+  RememberMe,
+  SafeAreaView,
+  HeaderTitle,
+  KeyboardAvoidingView
+} from './styles';
+
+export default function SignIn({ navigation }: NavigationInterface) {
+  const [values, setValues] = useState({
+    userName: '',
+    email: '',
+    phone: '',
+    password: ''
+  });
+
+  const { colors, fonts } = useThemeContext();
+
+  const onHandleChange = (field: string) => (value: string) => {
+    setValues({ ...values, [field]: value });
+  };
+
+  const handleSubmit = () => {
+    // dispatch action to submit form
+
+    // on success navigate to home screen
+    navigation.replace('HomeScreen');
+  };
+
+  return (
+    <SafeAreaView>
+      <Container>
+        <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={100}>
+          <Logo
+            testID="appLogo"
+            source={require('../../../assets/images/logo.png')}
+            style={{ resizeMode: 'contain', margin: 15 }}
+          />
+          <FormFields>
+            <InputFiled
+              placeholder="Email"
+              testID="email"
+              onChangeText={onHandleChange('email')}
+              defaultValue={values.email}
+              textContentType="emailAddress"
+              keyboardType="email-address"
+              style={{
+                borderTopStartRadius: 10,
+                borderTopEndRadius: 10
+              }}
+            >
+              <MailIcon />
+            </InputFiled>
+            <InputFiled
+              placeholder="Password"
+              testID="password"
+              onChangeText={onHandleChange('password')}
+              defaultValue={values.password}
+              secureTextEntry={true}
+              returnKeyType="done"
+              style={{
+                borderBottomStartRadius: 10,
+                borderBottomEndRadius: 10
+              }}
+            >
+              <PrivacyIcon />
+            </InputFiled>
+            <Conditions>
+              <BouncyCheckbox
+                isChecked
+                fillColor={colors.POST_TIP_COLOR}
+                fontSize={fonts.SMALL_SIZE + 2}
+                // iconComponent={your - own - component}
+                fontFamily={fonts.MONTSERRAT_SEMI_BOLD}
+                checkboxSize={20}
+                text="Remember Me"
+              />
+              <RememberMe></RememberMe>
+              <Button
+                title="forgot password?"
+                testID="resetAccount"
+                onPress={() => navigation.navigate('ForgotPasswordScreen')}
+                textStyle={{
+                  color: colors.FONT_LIGHT_COLOR,
+                  fontFamily: fonts.MONTSERRAT_SEMI_BOLD,
+                  fontSize: fonts.SMALL_SIZE + 2,
+                  textTransform: 'capitalize'
+                }}
+              />
+            </Conditions>
+          </FormFields>
+        </KeyboardAvoidingView>
+        <FormControls>
+          <Button
+            testID="loginButton"
+            buttonStyle={[
+              {
+                backgroundColor: colors.POST_TIP_COLOR,
+                borderRadius: 2
+              },
+              boxShadow({
+                elevation: 2,
+                color: 'rgba(175, 163, 180, 1)',
+                opacity: 0.3,
+                radius: 1,
+                height: 2.5
+              })
+            ]}
+            textStyle={{
+              color: colors.BG_LIGHT_COLOR,
+              textTransform: 'capitalize',
+              fontFamily: fonts.MONTSERRAT_SEMI_BOLD,
+              fontSize: fonts.MEDIUM_SIZE + 2
+            }}
+            title="login"
+            onPress={handleSubmit}
+          />
+          <Button
+            title="create account"
+            testID="createAccount"
+            onPress={() => navigation.navigate('SignUpScreen')}
+            textStyle={{
+              color: colors.FONT_DARK_COLOR,
+              fontFamily: fonts.MONTSERRAT_SEMI_BOLD,
+              fontSize: fonts.MEDIUM_SIZE + 2,
+              textTransform: 'capitalize'
+            }}
+            buttonStyle={[
+              {
+                borderRadius: 2,
+                marginTop: 15
+              },
+              boxShadow({
+                elevation: 0.3,
+                color: 'rgba(175, 163, 180, 0.45)',
+                opacity: 0.5,
+                radius: 10,
+                height: 0
+              })
+            ]}
+          />
+        </FormControls>
+      </Container>
+    </SafeAreaView>
+  );
+}
+
+SignIn.navigationOptions = ({ navigation, navigationOptions }) => {
+  const { navigationBackButton } = navigation.state;
+
+  return {
+    ...navigationOptions,
+    ...navigationBackButton,
+    headerTitle: () => <HeaderTitle>signin</HeaderTitle>,
+    headerStyle: { backgroundColor: '#F4F8FB' }
+  };
+};

--- a/src/screens/signin/index.tsx
+++ b/src/screens/signin/index.tsx
@@ -23,14 +23,9 @@ import {
 } from './styles';
 
 export default function SignIn({ navigation }: NavigationInterface) {
-  const [values, setValues] = useState({
-    userName: '',
-    email: '',
-    phone: '',
-    password: ''
-  });
-
   const { colors, fonts } = useThemeContext();
+
+  const [values, setValues] = useState({ email: '', password: '' });
 
   const onHandleChange = (field: string) => (value: string) => {
     setValues({ ...values, [field]: value });
@@ -86,7 +81,6 @@ export default function SignIn({ navigation }: NavigationInterface) {
                 isChecked
                 fillColor={colors.POST_TIP_COLOR}
                 fontSize={fonts.SMALL_SIZE + 2}
-                // iconComponent={your - own - component}
                 fontFamily={fonts.MONTSERRAT_SEMI_BOLD}
                 checkboxSize={20}
                 text="Remember Me"

--- a/src/screens/signin/styles.ts
+++ b/src/screens/signin/styles.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components/native';
+
+export const SafeAreaView = styled.SafeAreaView`
+  flex: 1;
+  background-color: ${({ theme }) => theme.colors.BD_DARK_COLOR};
+`;
+
+export const KeyboardAvoidingView = styled.KeyboardAvoidingView`
+  flex: 1;
+  align-items: center;
+`;
+
+export const HeaderTitle = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE}px;
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+  text-transform: capitalize;
+`;
+
+export const Container = styled.View`
+  flex: 1;
+  align-items: center;
+  padding: 0px 20px;
+`;
+
+export const Logo = styled.Image`
+  width: 100px;
+  height: 60px;
+`;
+
+export const FormFields = styled.View`
+  flex: 1;
+  justify-content: center;
+`;
+
+export const FormControls = styled.View`
+  flex: 0.6;
+  width: 100%;
+`;
+
+export const RememberMe = styled.Text`
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+  font-size: ${({ theme }) => theme.fonts.SMALL_SIZE + 2}px;
+  color: ${({ theme }) => theme.colors.FONT_LIGHT_COLOR};
+  text-transform: capitalize;
+`;
+
+export const Conditions = styled.View`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/src/screens/signup/index.tsx
+++ b/src/screens/signup/index.tsx
@@ -136,7 +136,7 @@ export default function SignUp({ navigation }: NavigationInterface) {
           <Button
             title="Log in"
             testID="loginButton"
-            onPress={() => navigation.navigate('LoginScreen')}
+            onPress={() => navigation.navigate('SignInScreen')}
             textStyle={{
               color: colors.POST_TIP_COLOR,
               fontFamily: fonts.MONTSERRAT_SEMI_BOLD,
@@ -166,9 +166,12 @@ export default function SignUp({ navigation }: NavigationInterface) {
   );
 }
 
-SignUp.navigationOptions = ({ navigationOptions }) => {
+SignUp.navigationOptions = ({ navigationOptions, navigation }) => {
+  const { navigationBackButton } = navigation.state;
+
   return {
     ...navigationOptions,
+    ...navigationBackButton,
     headerTitle: () => <HeaderTitle>signup</HeaderTitle>,
     headerStyle: { backgroundColor: '#F4F8FB' }
   };

--- a/src/screens/splash/index.tsx
+++ b/src/screens/splash/index.tsx
@@ -27,7 +27,7 @@ export default function SplashScreen({ navigation }: SplashScreenProp) {
         }),
       2000
     );
-    setTimeout(() => navigation.replace('HomeScreen'), 4000);
+    setTimeout(() => navigation.replace('SignInScreen'), 4000);
   }, []);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5796,6 +5796,11 @@ react-native-iphone-x-helper@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
 
+react-native-reanimated@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.4.0.tgz#7f1acbf9be08492d834f512700570978052be2f9"
+  integrity sha512-tO7nSNNP+iRLVbkcSS5GXyDBb7tSI02+XuRL3/S39EAr35rnvUy2JfeLUQG+fWSObJjnMVhasUDEUwlENk8IXw==
+
 react-native-safe-area-context@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.6.0.tgz#f53f5a5bcafb462a8798a26b145e68946389ad60"


### PR DESCRIPTION
#### What does this PR do?

Enable Users to sign in to the app with their details.

#### Description of Task to be completed?

Have the get started screen show the following:

1. A Top highlight o the app logo
2. Two input fields for user email and password.
3. A remember me checkbox for remembering user login
3. A login button that submits the form and leads to the home screen
4. A register button that leads to the signup screen

#### How should this be manually tested?

After cloning the repo,
`CD` into it and `RUN`

javascript
git checkout ft-login-screen

git pull origin ft-login-screen

yarn install

yarn test

Using an emulator: Launch the app, immediately after the splash screen you should see the get the login screen.

#### Screenshots (if appropriate)

![Simulator Screen Shot - iPhone 11 - 2020-02-27 at 10 03 38](https://user-images.githubusercontent.com/33870502/75428443-785b7b00-5948-11ea-9a8b-f5e916ad635d.png)
