### PR TITLE
Ft profile screen setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@expo/vector-icons": "^10.0.0",
     "@react-native-community/masked-view": "0.1.5",
+    "@types/react-native-snap-carousel": "^3.7.4",
     "expo": "~36.0.0",
     "expo-font": "~8.0.0",
     "expo-image-picker": "~8.0.1",
@@ -23,6 +24,7 @@
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
     "react-native-app-intro-slider": "^3.0.0",
+    "react-native-datepicker": "^1.7.2",
     "react-native-dotenv": "^0.2.0",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-optimized-flatlist": "^1.0.4",
@@ -32,6 +34,7 @@
     "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
     "react-native-skeleton-content": "^1.0.13",
+    "react-native-snap-carousel": "^3.8.4",
     "react-native-svg": "9.13.3",
     "react-native-tab-view": "^2.13.0",
     "react-native-web": "~0.11.7",

--- a/src/libs/profileSetupQuestion.json
+++ b/src/libs/profileSetupQuestion.json
@@ -1,0 +1,34 @@
+{
+  "questions": [
+    {
+      "key": "f7ebdc81-e819-4c54-b70e-f386513c60de",
+      "question": "When is your due date",
+      "id": 1
+    },
+    {
+      "key": "4971598c-5889-4cab-a316-8277db04db43",
+      "question": "Where do you live",
+      "id": 2
+    },
+    {
+      "key": "16885432-89f9-42d7-a306-4116577473f1",
+      "question": "Have you selected your birth hospital",
+      "id": 3
+    },
+    {
+      "key": "a1325d62-c554-4fed-a6df-3a427fe8a9b2",
+      "question": "Do you have HMO?",
+      "id": 4
+    },
+    {
+      "key": "f854cf49-fb3b-4a0c-afd7-cae7509280bf",
+      "question": "Are you interested in antenatal services",
+      "id": 5
+    },
+    {
+      "key": "45a87079-d319-4d2e-ac38-06be6c075bb2",
+      "question": "What are you interested in",
+      "id": 6
+    }
+  ]
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -96,6 +96,9 @@ const AppNavigator = createStackNavigator(
     // Splash Screen Route
     SplashScreen: { screen: Screens.SplashScreen },
 
+    // Profile Setup Screen Route
+    ProfileSetupScreen: { screen: Screens.ProfileSetupScreen },
+
     // Get started Screen Route
     GetStartedScreen: { screen: Screens.GetStartedScreen },
 

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -9,6 +9,7 @@ import ProfileScreen from './profile';
 import BlogDetailsScreen from './blog_details';
 import UserBlogDetailsScreen from './user_blog_details';
 import PostQuestionScreen from './post_question';
+import ProfileSetupScreen from './profile_setup';
 
 export default {
   SignUpScreen,
@@ -21,5 +22,6 @@ export default {
   ForgotPasswordScreen,
   BlogDetailsScreen,
   UserBlogDetailsScreen,
-  PostQuestionScreen
+  PostQuestionScreen,
+  ProfileSetupScreen
 };

--- a/src/screens/profile_setup/QuestionScreenItem.tsx
+++ b/src/screens/profile_setup/QuestionScreenItem.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import PageOne from './pageOne';
+import PageTwo from './pageTwo';
+import PageThree from './pageThree';
+import PageFour from './pageFour';
+import PageFive from './pageFive';
+import PageSix from './pageSix';
+
+import { SlideItem } from '.';
+
+import {
+  SlideQuestion,
+  SlideContainer,
+  SlideTitle,
+  SlideQuestionContainer,
+  SlideAnswersContainer
+} from './styles';
+
+type handleDataType = {
+  data: string;
+  type: string;
+};
+
+export default function QuestionScreenItem({
+  item,
+  questionRef,
+  setProfile,
+  profile
+}) {
+  const { key, question, id }: SlideItem = item;
+
+  const [navigation] = useState(questionRef);
+
+  const handleNavigation = () => navigation.snapToNext();
+
+  const handleChange = ({ data, type }: handleDataType) => {
+    setProfile(prev => ({ ...prev, payload: { [type]: data } }));
+  };
+
+  return (
+    <SlideContainer key={key}>
+      <SlideQuestionContainer>
+        <SlideQuestion>{question}</SlideQuestion>
+        <SlideTitle>profile setup</SlideTitle>
+      </SlideQuestionContainer>
+      <SlideAnswersContainer>
+        {id === 1 ? (
+          <PageOne
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+            profile={profile}
+          />
+        ) : null}
+        {id === 2 ? (
+          <PageTwo
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+            profile={profile}
+          />
+        ) : null}
+        {id === 3 ? (
+          <PageThree
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+          />
+        ) : null}
+        {id === 4 ? (
+          <PageFour
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+          />
+        ) : null}
+        {id === 5 ? (
+          <PageFive
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+          />
+        ) : null}
+        {id === 6 ? (
+          <PageSix
+            handleNavigation={handleNavigation}
+            handleChange={handleChange}
+            profile={profile}
+          />
+        ) : null}
+      </SlideAnswersContainer>
+    </SlideContainer>
+  );
+}

--- a/src/screens/profile_setup/index.tsx
+++ b/src/screens/profile_setup/index.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { AsyncStorage, Dimensions, StatusBar } from 'react-native';
+import Carousel from 'react-native-snap-carousel';
+import { Ionicons } from '@expo/vector-icons';
+import Animated, { Easing } from 'react-native-reanimated';
+import QuestionScreenItem from './QuestionScreenItem';
+import { useThemeContext } from '../../theme';
+import { useStoreContext } from '../../store';
+import { NavigationInterface } from '../../constants';
+import { questions as profileSetupQuestion } from '../../libs/profileSetupQuestion.json';
+import applyScale from '../../utils/applyScale';
+
+import {
+  Container,
+  QuestionContainer,
+  QuestionHeader,
+  SlideNumber,
+  SlideNumberLength,
+  SlideNumberContainer,
+  GoBack,
+  ProgressBar,
+  QuestionHeaderContent,
+  ProgressBarContainer
+} from './styles';
+
+const AnimatedProgressBar = Animated.createAnimatedComponent(ProgressBar);
+
+export type SlideItem = {
+  key: string;
+  question: string;
+  id: number;
+};
+
+interface ProfileSetupScreenProp extends NavigationInterface {
+  questions: SlideItem[];
+  testID?: string;
+}
+
+const { width: sliderWidth } = Dimensions.get('window');
+
+export default function ProfileSetupScreen({
+  navigation,
+  testID,
+  questions
+}: ProfileSetupScreenProp) {
+  const { colors } = useThemeContext();
+  const [, dispatch] = useStoreContext();
+
+  let questionRef = useRef(null);
+
+  const [profile, setProfile] = useState({
+    scrollIndex: 0,
+    animation: new Animated.Value(0),
+    payload: {
+      birthDueDate: new Date().toDateString(),
+      address: '',
+      birthHospital: '',
+      hasHMO: '',
+      antenatalInterest: '',
+      userInterest: ''
+    }
+  });
+
+  useEffect(() => {
+    startScrollBarAnimation();
+  }, [profile.scrollIndex]);
+
+  // @ts-ignore
+  const handleBackButton = () => questionRef.snapToPrev();
+
+  const startScrollBarAnimation = () => {
+    Animated.timing(profile.animation, {
+      toValue: applyScale(62.1 * profile.scrollIndex),
+      duration: 500,
+      easing: Easing.ease
+    }).start();
+  };
+
+  const handleStateChange = (scrollIndex: number) => {
+    setProfile({ ...profile, scrollIndex });
+  };
+
+  const handleSubmit = () => {
+    // dispatch user profile setup here
+  };
+
+  return (
+    <Container>
+      <StatusBar barStyle="dark-content" />
+      <QuestionHeader>
+        <QuestionHeaderContent>
+          <GoBack onPress={handleBackButton}>
+            {profile.scrollIndex !== 0 && (
+              <Ionicons
+                name="ios-arrow-back"
+                size={25}
+                color={colors.FONT_LIGHT_COLOR}
+              />
+            )}
+          </GoBack>
+          <SlideNumberContainer>
+            <SlideNumber>0{++profile.scrollIndex} </SlideNumber>
+            <SlideNumberLength>
+              / 0{profileSetupQuestion.length}
+            </SlideNumberLength>
+          </SlideNumberContainer>
+        </QuestionHeaderContent>
+        <ProgressBarContainer>
+          <AnimatedProgressBar
+            style={{
+              width: profile.animation,
+              backgroundColor: colors.FLOATING_MESSAGE_COLOR,
+              zIndex: 999
+            }}
+          />
+          <ProgressBar />
+        </ProgressBarContainer>
+      </QuestionHeader>
+      <QuestionContainer>
+        <Carousel
+          testID="profile-setup-slider"
+          ref={c => (questionRef = c)}
+          data={questions}
+          renderItem={props => (
+            <QuestionScreenItem
+              {...props}
+              questionRef={questionRef}
+              setProfile={setProfile}
+              profile={profile.payload}
+            />
+          )}
+          sliderWidth={sliderWidth}
+          itemWidth={sliderWidth}
+          layout={'stack'}
+          layoutCardOffset={10}
+          shouldOptimizeUpdates={true}
+          onSnapToItem={scrollIndex => handleStateChange(scrollIndex)}
+        />
+      </QuestionContainer>
+    </Container>
+  );
+}
+
+ProfileSetupScreen.defaultProps = { questions: profileSetupQuestion };
+
+ProfileSetupScreen.navigationOptions = { headerShown: false };

--- a/src/screens/profile_setup/pageFive.tsx
+++ b/src/screens/profile_setup/pageFive.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import RNPickerSelect from 'react-native-picker-select';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageFive({ handleNavigation, handleChange }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string, answer: string) => {
+    if (buttonType === animation.selected) {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      handleChange({ type: 'hasHMO', data: answer });
+      setTimeout(handleNavigation, 500);
+    });
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Yes</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthOne', 'yes')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            Yes
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>No</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo', 'no')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            No
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}

--- a/src/screens/profile_setup/pageFour.tsx
+++ b/src/screens/profile_setup/pageFour.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import RNPickerSelect from 'react-native-picker-select';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageFour({ handleNavigation, handleChange }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string, answer: string) => {
+    if (buttonType === animation.selected) {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      handleChange({ type: 'antenatalInterest', data: answer });
+      setTimeout(handleNavigation, 500);
+    });
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Yes</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthOne', 'yes')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            Yes
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>No</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo', 'no')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            No
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}

--- a/src/screens/profile_setup/pageOne.tsx
+++ b/src/screens/profile_setup/pageOne.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import DatePicker from 'react-native-datepicker';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageOne({ handleNavigation, handleChange, profile }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string) => {
+    if (buttonType === animation.selected && buttonType === 'buttonWidthTwo') {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      if (buttonType === 'buttonWidthTwo') {
+        setTimeout(handleNavigation, 500);
+      }
+    });
+  };
+
+  const handleDate = (date: string) => {
+    handleChange({ type: 'birthDueDate', data: date });
+    setTimeout(handleNavigation, 500);
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Select date</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton style={{ backgroundColor: 'transparent' }}>
+          <DatePicker
+            style={{
+              position: 'absolute',
+              width: applyScale(373)
+            }}
+            mode="date"
+            placeholder=" "
+            format="DD-MM-YYYY"
+            minDate={new Date()}
+            maxDate="01-03-2060"
+            confirmBtnText="Confirm"
+            cancelBtnText="Cancel"
+            showIcon={false}
+            customStyles={{
+              dateInput: { height: applyScale(60), borderWidth: 0 }
+            }}
+            onDateChange={handleDate}
+            onOpenModal={() => startButtonAnimation('buttonWidthOne')}
+            getDateStr={(date: Date) => new Date(date).toDateString()}
+          />
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            {animation.selected === 'buttonWidthOne'
+              ? profile.birthDueDate
+              : null}
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>Continue</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            Continue
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}

--- a/src/screens/profile_setup/pageSix.tsx
+++ b/src/screens/profile_setup/pageSix.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import RNPickerSelect from 'react-native-picker-select';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageSix({ handleNavigation, handleChange, profile }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string) => {
+    if (buttonType === animation.selected && buttonType === 'buttonWidthTwo') {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      if (buttonType === 'buttonWidthTwo') {
+        setTimeout(handleNavigation, 500);
+      }
+    });
+  };
+
+  const handleState = (userInterest: string) => {
+    handleChange({ type: 'antenatalInterest', data: userInterest });
+  };
+
+  const handleRNPickerSelect = () => {
+    startButtonAnimation('buttonWidthOne');
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Select interest</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+
+        {animation.selected === 'buttonWidthOne' ? (
+          <AnswerOption
+            style={{
+              color: colors.POST_TIP_COLOR,
+              position: 'absolute',
+              left: 37
+            }}
+          >
+            a
+          </AnswerOption>
+        ) : null}
+
+        <SelectQuestionButton style={{ backgroundColor: 'transparent' }}>
+          <RNPickerSelect
+            onOpen={handleRNPickerSelect}
+            onClose={() => setTimeout(handleNavigation, 1000)}
+            placeholder={{
+              label: `${
+                animation.selected === 'buttonWidthOne'
+                  ? 'Select an interest...'
+                  : ''
+              }`,
+              value: 'Abia',
+              color: 'red',
+              key: 'Select an interest...'
+            }}
+            onValueChange={handleState}
+            value={profile.userInterest}
+            items={allStates.map((title: string, index: number) => ({
+              label: title,
+              value: title,
+              key: index
+            }))}
+            textInputProps={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR,
+              width: applyScale(373),
+              height: applyScale(63),
+              paddingLeft: applyScale(85)
+            }}
+          />
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            Select interest
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>Continue</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            Continue
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}
+
+const allStates = ['Parenting', 'Health', 'Contraceptives', 'IVF'];

--- a/src/screens/profile_setup/pageThree.tsx
+++ b/src/screens/profile_setup/pageThree.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import RNPickerSelect from 'react-native-picker-select';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageThree({ handleNavigation, handleChange }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string, answer: string) => {
+    if (buttonType === animation.selected) {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      handleChange({ type: 'birthHospital', data: answer });
+      setTimeout(handleNavigation, 500);
+    });
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Yes</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthOne', 'yes')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            Yes
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>No</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo', 'no')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            No
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}

--- a/src/screens/profile_setup/pageTwo.tsx
+++ b/src/screens/profile_setup/pageTwo.tsx
@@ -1,0 +1,227 @@
+import React, { useState } from 'react';
+import Animated, { Easing } from 'react-native-reanimated';
+import RNPickerSelect from 'react-native-picker-select';
+import { useThemeContext } from '../../theme';
+import applyScale from '../../utils/applyScale';
+
+import {
+  PageOneContainer,
+  SelectQuestionButtonContainer,
+  AnswerOption,
+  AnswerOptionText,
+  SelectQuestionButton
+} from './styles';
+
+const SelectQuestionButtonOverlay = Animated.createAnimatedComponent(
+  SelectQuestionButton
+);
+
+export default function PageTwo({ handleNavigation, handleChange, profile }) {
+  const { colors } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    buttonWidthOne: new Animated.Value(applyScale(5)),
+    buttonWidthTwo: new Animated.Value(applyScale(5)),
+    selected: ''
+  });
+
+  const startButtonAnimation = (buttonType: string) => {
+    if (buttonType === animation.selected && buttonType === 'buttonWidthTwo') {
+      return setTimeout(handleNavigation, 500);
+    }
+
+    setAnimation({ ...animation, selected: buttonType });
+
+    if (animation.selected && buttonType !== animation.selected) {
+      Animated.timing(animation[animation.selected], {
+        toValue: applyScale(5),
+        duration: 300,
+        easing: Easing.elastic(0.7)
+      }).start();
+    }
+
+    Animated.timing(animation[buttonType], {
+      toValue: applyScale(373),
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      if (buttonType === 'buttonWidthTwo') {
+        setTimeout(handleNavigation, 500);
+      }
+    });
+  };
+
+  const handleState = (state: string) => {
+    handleChange({ type: 'address', data: state });
+  };
+
+  const handleRNPickerSelect = () => {
+    startButtonAnimation('buttonWidthOne');
+  };
+
+  return (
+    <PageOneContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>a</AnswerOption>
+          <AnswerOptionText>Select state</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthOne,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+
+        {animation.selected === 'buttonWidthOne' ? (
+          <AnswerOption
+            style={{
+              color: colors.POST_TIP_COLOR,
+              position: 'absolute',
+              left: 37
+            }}
+          >
+            a
+          </AnswerOption>
+        ) : null}
+
+        <SelectQuestionButton style={{ backgroundColor: 'transparent' }}>
+          <RNPickerSelect
+            onOpen={handleRNPickerSelect}
+            onClose={() => setTimeout(handleNavigation, 1000)}
+            placeholder={{
+              label: `${
+                animation.selected === 'buttonWidthOne'
+                  ? 'Select a state...'
+                  : ''
+              }`,
+              value: 'Select a state...',
+              color: 'red',
+              key: 'Select a state...'
+            }}
+            onValueChange={handleState}
+            value={profile.address}
+            items={allStates.map((title: string, index: number) => ({
+              label: title,
+              value: title,
+              key: index
+            }))}
+            textInputProps={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR,
+              width: applyScale(373),
+              height: applyScale(63),
+              paddingLeft: applyScale(85)
+            }}
+          />
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            a
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthOne'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR
+            }}
+          >
+            Select state
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+      <SelectQuestionButtonContainer>
+        <SelectQuestionButton>
+          <AnswerOption>b</AnswerOption>
+          <AnswerOptionText>Continue</AnswerOptionText>
+        </SelectQuestionButton>
+        <SelectQuestionButtonOverlay
+          style={{
+            width: animation.buttonWidthTwo,
+            backgroundColor: colors.BG_LIGHT_COLOR,
+            alignSelf: 'flex-start',
+            borderLeftWidth: 0,
+            left: -5
+          }}
+        />
+        <SelectQuestionButton
+          style={{ backgroundColor: 'transparent' }}
+          onPress={() => startButtonAnimation('buttonWidthTwo')}
+        >
+          <AnswerOption
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.POST_TIP_COLOR
+                  : colors.BD_DARK_COLOR
+            }}
+          >
+            b
+          </AnswerOption>
+          <AnswerOptionText
+            style={{
+              color:
+                animation.selected === 'buttonWidthTwo'
+                  ? colors.FLOATING_MESSAGE_COLOR
+                  : colors.BG_LIGHT_COLOR,
+              zIndex: 999
+            }}
+          >
+            Continue
+          </AnswerOptionText>
+        </SelectQuestionButton>
+      </SelectQuestionButtonContainer>
+    </PageOneContainer>
+  );
+}
+
+const allStates = [
+  'Abia',
+  'Adamawa',
+  'Akwa Ibom',
+  'Anambra',
+  'Bauchi',
+  'Bayelsa',
+  'Benue',
+  'Borno',
+  'Cross River',
+  'Delta',
+  'Ebonyi',
+  'Edo',
+  'Ekiti',
+  'Enugu',
+  'FCT - Abuja',
+  'Gombe',
+  'Imo',
+  'Jigawa',
+  'Kaduna',
+  'Kano',
+  'Katsina',
+  'Kebbi',
+  'Kogi',
+  'Kwara',
+  'Lagos',
+  'Nasarawa',
+  'Niger',
+  'Ogun',
+  'Ondo',
+  'Osun',
+  'Oyo',
+  'Plateau',
+  'Rivers',
+  'Sokoto',
+  'Taraba',
+  'Yobe',
+  'Zamfara'
+];

--- a/src/screens/profile_setup/styles.ts
+++ b/src/screens/profile_setup/styles.ts
@@ -1,0 +1,157 @@
+import styled from 'styled-components/native';
+import applyScale from '../../utils/applyScale';
+
+export const Container = styled.View`
+  flex: 1;
+  align-items: center;
+`;
+
+export const QuestionHeader = styled.View`
+  width: 100%;
+  height: ${applyScale(100)}px;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
+`;
+
+export const QuestionHeaderContent = styled.View`
+  height: 100%;
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 10px;
+`;
+
+export const QuestionContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.FLOATING_MESSAGE_COLOR};
+`;
+
+export const SlideContainer = styled.View`
+  flex: 1;
+  justify-content: flex-end;
+  background-color: ${({ theme }) => theme.colors.BG_LIGHT_COLOR};
+  border-radius: 3px;
+`;
+
+export const SlideNumberContainer = styled.View`
+  width: 55%;
+  height: 60%;
+  height: 40px;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const SlideNumber = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE + 10}px;
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+`;
+
+export const SlideNumberLength = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE}px;
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+  color: ${({ theme }) => theme.colors.INACTIVE_ICON_COLOR};
+`;
+
+export const SlideTitle = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_REGULAR};
+  color: ${({ theme }) => theme.colors.INACTIVE_ICON_COLOR};
+  text-transform: capitalize;
+  height: 10%;
+`;
+
+export const SlideQuestionContainer = styled.View`
+  width: 100%;
+  height: 40%;
+  justify-content: space-between;
+  padding: 10px 15px;
+`;
+
+export const SlideQuestion = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE + 25}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+`;
+
+export const GoBack = styled.TouchableOpacity`
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ProgressBarContainer = styled.View`
+  width: 90%;
+  height: 9px;
+  border-radius: 3px;
+  justify-content: center;
+  position: relative;
+  background-color: ${({ theme }) => theme.colors.BD_DARK_COLOR};
+`;
+
+export const ProgressBar = styled.View`
+  width: 100%;
+  height: 9px;
+  border-radius: 3px;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  background-color: ${({ theme }) => theme.colors.BD_DARK_COLOR};
+`;
+
+export const SlideAnswersContainer = styled.View`
+  width: 100%;
+  height: 40%;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 20px;
+  background-color: ${({ theme }) => theme.colors.FLOATING_MESSAGE_COLOR};
+`;
+
+export const PageOneContainer = styled.View`
+  flex: 1;
+  width: 100%;
+  align-items: center;
+`;
+
+export const SelectQuestionButtonContainer = styled.View`
+  width: 100%;
+  height: 60px;
+  align-items: center;
+  justify-content: center;
+  margin: 5px;
+`;
+
+export const SelectQuestionButton = styled.TouchableOpacity`
+  width: 100%;
+  height: 60px;
+  flex-direction: row;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.GRADIENT_COLOR_FROM};
+  margin: 5px;
+  position: absolute;
+`;
+
+export const AnswerOption = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_REGULAR};
+  color: ${({ theme }) => theme.colors.BD_DARK_COLOR};
+  flex: 0.3;
+  text-align: center;
+`;
+
+export const AnswerOptionText = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_REGULAR};
+  color: ${({ theme }) => theme.colors.BG_LIGHT_COLOR};
+  flex: 1;
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,14 @@
   resolved "https://registry.yarnpkg.com/@types/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz#32c58422a422c1adf68acce363ed791314d5a8e7"
   integrity sha512-ZxX+dU/yoQc0jTk+/NWttkiuXceJyN5FpOSqDl0WynN5GDzxwH7OMruQ47qcY8llo2RD3irjvzJ9BwC8gDiq0A==
 
+"@types/react-native-snap-carousel@^3.7.4":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@types/react-native-snap-carousel/-/react-native-snap-carousel-3.7.4.tgz#1e1ad5b5314715d538f6785b4f3a6590a036a6bd"
+  integrity sha512-Egwj264i8lQtp4O8+TXse2yagW5im8oPzPcfWzIEYspKspPE0NikqWFtpVrecgbd/uwhwEjLXLY5kEXOvpiJjA==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+
 "@types/react-native@*":
   version "0.61.17"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.61.17.tgz#5994af207c2339d498ebd8bd427c68074ce9e744"
@@ -5045,6 +5053,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 morgan@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -5774,6 +5787,14 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+react-addons-shallow-compare@15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
+  integrity sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
+
 react-devtools-core@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-3.6.3.tgz#977d95b684c6ad28205f0c62e1e12c5f16675814"
@@ -5801,6 +5822,13 @@ react-native-app-intro-slider@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-native-app-intro-slider/-/react-native-app-intro-slider-3.0.0.tgz#c3620b967503ce410b3d767252392bb6fb2edf97"
   integrity sha512-2XXUYnSeMYZTLhdRYHSwv8mhoyuEaYxmQfXrWQInH1QvjsnJtKgvORI3bJuJN+tNPg3aut6JYYCNOFsI5of32A==
+
+react-native-datepicker@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/react-native-datepicker/-/react-native-datepicker-1.7.2.tgz#58d0822591a0ac9b32aba082650222a0ee29669d"
+  integrity sha1-WNCCJZGgrJsyq6CCZQIioO4pZp0=
+  dependencies:
+    moment "^2.22.0"
 
 react-native-dotenv@^0.2.0:
   version "0.2.0"
@@ -5886,6 +5914,14 @@ react-native-skeleton-content@^1.0.13:
   dependencies:
     expo-linear-gradient "^8.0.0"
     lodash "^4.17.14"
+
+react-native-snap-carousel@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.8.4.tgz#4c749c6a714d46ed82de527233850cb5da41bc62"
+  integrity sha512-KMxLl75Tyf12DzeTCtV7xU0KuPZQQs/2+2iM90cgxcm3lrg4+hLXff5/61ynasBkzzJ5v4bTRq5CEy/qGUJVQw==
+  dependencies:
+    prop-types "^15.6.1"
+    react-addons-shallow-compare "15.6.2"
 
 react-native-svg@9.13.3:
   version "9.13.3"


### PR DESCRIPTION
#### What does this PR do?

Have an overview feature of the app displayed in get started screen.

#### Description of Task to be completed?

Have the get started screen show the following:

1. Slider to show a brief description of core features of the app.
2. A slider pagination to show current slide position.
3. A get started button that leads to the sign up screen
4. A login button that leads to login screen

#### How should this be manually tested?

After cloning the repo,
`CD` into it and `RUN`

javascript
git checkout ft-get-started-screen

git pull origin ft-get-started-screen

yarn install

yarn test

Using an emulator: Launch the app, immediately after the splash screen you should see the get started screen.

#### Screenshots (if appropriate)

![Simulator Screen Shot - iPhone Xs - 2020-02-24 at 09 56 16](https://user-images.githubusercontent.com/12932317/75139025-e9eabd80-56eb-11ea-944f-93bec2b9e9d1.png)
