### PR TITLE
add user profile component

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-native-community/masked-view": "0.1.5",
     "@types/react-native-snap-carousel": "^3.7.4",
     "expo": "~36.0.0",
+    "expo-constants": "~8.0.0",
     "expo-font": "~8.0.0",
     "expo-image-picker": "~8.0.1",
     "expo-linear-gradient": "^8.0.0",

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -9,8 +9,8 @@ type PostProps = {
   onLayout?(): void;
 };
 
-const Post: FunctionComponent<PostProps> = props => {
+const Card: FunctionComponent<PostProps> = props => {
   return <Container {...props}>{props.children}</Container>;
 };
 
-export default Post;
+export default Card;

--- a/src/components/inputField/index.tsx
+++ b/src/components/inputField/index.tsx
@@ -22,6 +22,8 @@ type InputFieldProps = {
   returnKeyType?: any;
   secureTextEntry?: boolean;
   style?: object;
+  disable?: boolean;
+  activeColor?: string;
 };
 
 const InputFiled: FunctionComponent<InputFieldProps> = props => {
@@ -37,7 +39,8 @@ const InputFiled: FunctionComponent<InputFieldProps> = props => {
     returnKeyType = 'next',
     secureTextEntry = false,
     style,
-    testID
+    testID,
+    disable = false
   } = props;
 
   const [inputState, setInputState] = useState({
@@ -116,7 +119,7 @@ const InputFiled: FunctionComponent<InputFieldProps> = props => {
         style,
         {
           backgroundColor: inputState.activateColor
-            ? colors.IDLE_INPUT_COLOR
+            ? props.activeColor || colors.IDLE_INPUT_COLOR
             : colors.BG_LIGHT_COLOR
         }
       ]}
@@ -138,6 +141,7 @@ const InputFiled: FunctionComponent<InputFieldProps> = props => {
           keyboardType={keyboardType}
           returnKeyType={returnKeyType}
           secureTextEntry={secureTextEntry}
+          editable={!disable}
         />
         {inputState.canShowIsValid && (
           <CheckedContainer>

--- a/src/components/userPost/index.tsx
+++ b/src/components/userPost/index.tsx
@@ -7,6 +7,8 @@ import {
   Dimensions
 } from 'react-native';
 import ContentLoader from 'react-native-skeleton-content';
+import boxShadow from '../../utils/boxShadows';
+import { useThemeContext } from '../../theme';
 import applyScale from '../../utils/applyScale';
 
 import ResponsiveImage from '../../libs/responsiveImage';
@@ -40,6 +42,8 @@ interface UserPostProps extends PostInterface {
 const { width: DEVICE_WIDTH } = Dimensions.get('window');
 
 export default function UserPost(props: UserPostProps) {
+  const { colors } = useThemeContext();
+
   const { topic, description, noOfLikes, noOfViews, testID, width } = props;
 
   const postDescription =
@@ -72,11 +76,21 @@ export default function UserPost(props: UserPostProps) {
 
   return (
     <Card
-      style={{
-        width: applyScale(width),
-        margin: 10,
-        height: DEVICE_WIDTH <= 375 ? applyScale(280) : applyScale(250)
-      }}
+      style={[
+        {
+          width: applyScale(width),
+          margin: 10,
+          height: DEVICE_WIDTH <= 375 ? applyScale(280) : applyScale(250)
+        },
+        boxShadow({
+          width: 0,
+          height: 0,
+          color: colors.IDLE_INPUT_COLOR,
+          opacity: 0.3,
+          radius: 1,
+          elevation: 2
+        })
+      ]}
       onPress={props.navigation}
     >
       <Container testID={testID} style={{}}>

--- a/src/screens/profile/index.tsx
+++ b/src/screens/profile/index.tsx
@@ -1,19 +1,484 @@
-import React from 'react';
+import React, { useState, Fragment } from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  TouchableWithoutFeedback,
+  Keyboard,
+  KeyboardAvoidingView
+} from 'react-native';
+import ContentLoader from 'react-native-skeleton-content';
+import Animated, { Easing } from 'react-native-reanimated';
+import { Entypo, Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
+import { NavigationInterface } from '../../constants';
+import { useThemeContext } from '../../theme';
 
 import Button from '../../components/button';
-import { Container, Welcome } from './styles';
-import { NavigationInterface } from '../../constants';
+import applyScale from '../../utils/applyScale';
+import ResponsiveImage from '../../libs/responsiveImage';
+import boxShadow from '../../utils/boxShadows';
+import InputFiled from '../../components/inputField';
+import MailIcon from '../../../assets/icons/mail';
+import PrivacyIcon from '../../../assets/icons/privacy';
+import PhoneIcon from '../../../assets/icons/phone';
+
+import {
+  StatusBar,
+  Container,
+  HeaderContainer,
+  ProfileImageContainer,
+  IconContainer,
+  ProfileDetailsContainer,
+  UserName,
+  UserEmail,
+  ScrollViewContainer,
+  AccountSettingTitle,
+  AccountSettingContainer,
+  OptionContainer,
+  OptionTitle,
+  OptionContainerHeader,
+  OptionContainerFooter,
+  ProfileRecordsContainer,
+  ProfileResultsContainer,
+  RecordsTitle,
+  RecordsResult
+} from './styles';
+
+const AnimatedOptionContainer = Animated.createAnimatedComponent(
+  OptionContainer
+);
+
+const AnimatedOptionContainerFooter = Animated.createAnimatedComponent(
+  OptionContainerFooter
+);
 
 interface ProfileScreenProp extends NavigationInterface {
   testID?: string;
 }
 
+const SCALED_WIDTH = applyScale(120);
+
 export default function ProfileScreen(props: ProfileScreenProp) {
+  const { colors, fonts } = useThemeContext();
+
+  const [animation, setAnimation] = useState({
+    animateContentHeightOne: new Animated.Value(applyScale(70)),
+    animateContentHeightTwo: new Animated.Value(applyScale(70)),
+    animateContentHeightThree: new Animated.Value(applyScale(70)),
+    animateInputsOne: {
+      value: new Animated.Value(0),
+      showInputsModal: true
+    },
+    animateInputsTwo: {
+      value: new Animated.Value(0),
+      showInputsModal: true
+    },
+    animateInputsThree: {
+      value: new Animated.Value(0),
+      showInputsModal: true
+    },
+    hideContentLoader: true,
+    email: '',
+    password: '',
+    address: '',
+    phone: '',
+    selected: ''
+  });
+
+  const onHandleChange = (field: string) => (value: string) => {
+    setAnimation({ ...animation, [field]: value });
+  };
+
+  const handleSubmit = () => {
+    // dispatch action to submit form
+  };
+
+  const handleImageLoading = (error: any) => {
+    if (!error) {
+      setAnimation({ ...animation, hideContentLoader: false });
+    }
+  };
+
+  const handleLogout = () => {
+    // handle user logout logic here
+  };
+
+  const startEditAnimation = (buttonType: string) => {
+    setAnimation({ ...animation, selected: buttonType });
+
+    let animateInputs = 'animateInputsOne';
+
+    switch (buttonType) {
+      case 'animateContentHeightOne':
+        animateInputs = animateInputs;
+        break;
+      case 'animateContentHeightTwo':
+        animateInputs = 'animateInputsTwo';
+        break;
+      case 'animateContentHeightThree':
+        animateInputs = 'animateInputsThree';
+        break;
+      case 'animateContentHeightThree':
+        animateInputs = 'animateInputsThree';
+        break;
+      default:
+        break;
+    }
+
+    const { showInputsModal } = animation[animateInputs];
+
+    if (showInputsModal) {
+      return showInputModal(animateInputs, buttonType);
+    }
+    closeInputModal(animateInputs, buttonType);
+  };
+
+  const closeInputModal = (animateInputs: string, buttonType: string) => {
+    const animationProps = animation[animateInputs];
+
+    Animated.timing(animationProps.value, {
+      toValue: 0,
+      duration: 50,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      Animated.timing(animation[buttonType], {
+        toValue: 70,
+        duration: 500,
+        easing: Easing.elastic(0.7)
+      }).start(() => {
+        setAnimation({
+          ...animation,
+          [animateInputs]: { ...animationProps, showInputsModal: true }
+        });
+      });
+    });
+  };
+
+  const showInputModal = (animateInputs: string, buttonType: string) => {
+    const animationProps = animation[animateInputs];
+
+    Animated.timing(animation[buttonType], {
+      toValue: buttonType === 'animateContentHeightThree' ? 220 : 150,
+      duration: 500,
+      easing: Easing.elastic(0.7)
+    }).start(() => {
+      Animated.timing(animationProps.value, {
+        toValue: 1,
+        duration: 50,
+        easing: Easing.elastic(0.4)
+      }).start(() => {
+        setAnimation({
+          ...animation,
+          [animateInputs]: { ...animationProps, showInputsModal: false }
+        });
+      });
+    });
+  };
+
   return (
-    <Container testID="ProfileScreen">
-      <Button title="Profile screen button" />
-      <Welcome>Profile Screen</Welcome>
-    </Container>
+    <Fragment>
+      <StatusBar />
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <SafeAreaView
+          style={{ flex: 1, backgroundColor: colors.BD_DARK_COLOR }}
+        >
+          <HeaderContainer
+            style={[
+              boxShadow({
+                width: 0,
+                height: 2,
+                color: colors.ACTIVE_TAB_COLOR,
+                opacity: 0.08,
+                radius: 1,
+                elevation: 3
+              })
+            ]}
+          >
+            <Button
+              title="logout"
+              buttonStyle={{
+                backgroundColor: 'transparent',
+                position: 'absolute',
+                right: 10,
+                top: 10
+              }}
+              textStyle={{
+                color: colors.FLOATING_MESSAGE_COLOR,
+                fontFamily: fonts.IBM_SANS_BOLD
+              }}
+              onPress={handleLogout}
+            />
+            <ProfileImageContainer>
+              <ContentLoader
+                isLoading={animation.hideContentLoader}
+                containerStyle={{
+                  width: SCALED_WIDTH,
+                  height: SCALED_WIDTH
+                }}
+                layout={[
+                  {
+                    width: SCALED_WIDTH,
+                    height: SCALED_WIDTH,
+                    borderRadius: 120 / 2
+                  }
+                ]}
+              />
+              <ResponsiveImage
+                imageUrl="https://bit.ly/38taXRW"
+                height={SCALED_WIDTH}
+                width={SCALED_WIDTH}
+                onLoad={handleImageLoading}
+                style={{ borderRadius: 120 / 2 }}
+              />
+              <IconContainer
+                activeOpacity={1}
+                style={{
+                  borderRadius: 40 / 2,
+                  position: 'absolute',
+                  bottom: 0,
+                  right: 0
+                }}
+              >
+                <Entypo name="camera" size={20} color={colors.BD_DARK_COLOR} />
+              </IconContainer>
+            </ProfileImageContainer>
+            <ProfileDetailsContainer>
+              <UserName>Ethel Ford Ethel</UserName>
+              <UserEmail>ethel.ford@example.com</UserEmail>
+            </ProfileDetailsContainer>
+            <ProfileRecordsContainer>
+              <ProfileResultsContainer>
+                <RecordsResult>12</RecordsResult>
+                <RecordsTitle>posts</RecordsTitle>
+              </ProfileResultsContainer>
+              <ProfileResultsContainer>
+                <RecordsResult>63</RecordsResult>
+                <RecordsTitle>comments</RecordsTitle>
+              </ProfileResultsContainer>
+            </ProfileRecordsContainer>
+          </HeaderContainer>
+          <KeyboardAvoidingView style={{ flex: 1 }} behavior="position" enabled>
+            <ScrollView
+              contentContainerStyle={{ paddingBottom: 60 }}
+              showsVerticalScrollIndicator={false}
+            >
+              <Container testID={props.testID}>
+                <ScrollViewContainer>
+                  <AccountSettingTitle>account setting</AccountSettingTitle>
+                  <AccountSettingContainer
+                    style={[
+                      boxShadow({
+                        width: 0,
+                        height: 2,
+                        color: colors.INACTIVE_ICON_COLOR,
+                        opacity: 0.25,
+                        radius: 3.84,
+                        elevation: 5
+                      })
+                    ]}
+                  >
+                    <AnimatedOptionContainer
+                      activeOpacity={0.8}
+                      style={{ height: animation.animateContentHeightOne }}
+                      onPress={() =>
+                        startEditAnimation('animateContentHeightOne')
+                      }
+                    >
+                      <OptionContainerHeader
+                        activeOpacity={0.8}
+                        onPress={() =>
+                          startEditAnimation('animateContentHeightOne')
+                        }
+                      >
+                        <IconContainer
+                          activeOpacity={1}
+                          disabled
+                          style={{
+                            height: applyScale(35),
+                            width: applyScale(35),
+                            borderRadius: 3,
+                            backgroundColor: colors.LIKE_POST_COLOR
+                          }}
+                        >
+                          <MaterialCommunityIcons
+                            name="email"
+                            size={20}
+                            color={colors.BG_LIGHT_COLOR}
+                          />
+                        </IconContainer>
+                        <OptionTitle>update email address</OptionTitle>
+                        <Ionicons
+                          name="ios-arrow-down"
+                          size={20}
+                          color={colors.INACTIVE_ICON_COLOR}
+                        />
+                      </OptionContainerHeader>
+                      <AnimatedOptionContainerFooter
+                        style={{
+                          opacity: animation.animateInputsOne.value,
+                          display: !animation.animateInputsOne.showInputsModal
+                            ? 'flex'
+                            : 'none'
+                        }}
+                      >
+                        <InputFiled
+                          placeholder="Ethel.ford@example.com"
+                          testID="email"
+                          onChangeText={onHandleChange('email')}
+                          defaultValue={animation.email}
+                          textContentType="emailAddress"
+                          keyboardType="email-address"
+                          disable={true}
+                          style={{ borderRadius: 5 }}
+                        >
+                          <MailIcon />
+                        </InputFiled>
+                      </AnimatedOptionContainerFooter>
+                    </AnimatedOptionContainer>
+                    <AnimatedOptionContainer
+                      style={{
+                        height: animation.animateContentHeightTwo,
+                        borderWidth: 1,
+                        borderLeftWidth: 0,
+                        borderRightWidth: 0,
+                        borderColor: colors.INACTIVE_ICON_COLOR
+                      }}
+                    >
+                      <OptionContainerHeader
+                        activeOpacity={0.8}
+                        onPress={() =>
+                          startEditAnimation('animateContentHeightTwo')
+                        }
+                      >
+                        <IconContainer
+                          activeOpacity={1}
+                          disabled
+                          style={{
+                            height: applyScale(35),
+                            width: applyScale(35),
+                            borderRadius: 3,
+                            backgroundColor: colors.USER_POST_COLOR
+                          }}
+                        >
+                          <Ionicons
+                            name="ios-key"
+                            size={20}
+                            color={colors.BG_LIGHT_COLOR}
+                          />
+                        </IconContainer>
+                        <OptionTitle>change password</OptionTitle>
+                        <Ionicons
+                          name="ios-arrow-down"
+                          size={20}
+                          color={colors.INACTIVE_ICON_COLOR}
+                        />
+                      </OptionContainerHeader>
+                      <AnimatedOptionContainerFooter
+                        style={{
+                          opacity: animation.animateInputsTwo.value,
+                          display: !animation.animateInputsTwo.showInputsModal
+                            ? 'flex'
+                            : 'none'
+                        }}
+                      >
+                        <InputFiled
+                          placeholder="Password"
+                          testID="password"
+                          onChangeText={onHandleChange('password')}
+                          defaultValue={animation.password}
+                          secureTextEntry={true}
+                          returnKeyType="done"
+                          activeColor={colors.BG_LIGHT_COLOR}
+                          style={{ borderRadius: 5 }}
+                        >
+                          <PrivacyIcon />
+                        </InputFiled>
+                      </AnimatedOptionContainerFooter>
+                    </AnimatedOptionContainer>
+                    <AnimatedOptionContainer
+                      style={{ height: animation.animateContentHeightThree }}
+                    >
+                      <OptionContainerHeader
+                        activeOpacity={0.8}
+                        onPress={() =>
+                          startEditAnimation('animateContentHeightThree')
+                        }
+                      >
+                        <IconContainer
+                          activeOpacity={1}
+                          disabled
+                          style={{
+                            height: applyScale(35),
+                            width: applyScale(35),
+                            borderRadius: 3
+                          }}
+                        >
+                          <MaterialCommunityIcons
+                            name="account-card-details"
+                            size={20}
+                            color={colors.BG_LIGHT_COLOR}
+                          />
+                        </IconContainer>
+                        <OptionTitle>update my details</OptionTitle>
+                        <Ionicons
+                          name="ios-arrow-down"
+                          size={20}
+                          color={colors.INACTIVE_ICON_COLOR}
+                        />
+                      </OptionContainerHeader>
+                      <AnimatedOptionContainerFooter
+                        style={{
+                          opacity: animation.animateInputsThree.value,
+                          display: !animation.animateInputsThree.showInputsModal
+                            ? 'flex'
+                            : 'none'
+                        }}
+                      >
+                        <InputFiled
+                          placeholder="Phone"
+                          testID="phone"
+                          onChangeText={onHandleChange('phone')}
+                          defaultValue={animation.phone}
+                          secureTextEntry={true}
+                          returnKeyType="done"
+                          activeColor={colors.BG_LIGHT_COLOR}
+                          style={{ borderRadius: 5 }}
+                        >
+                          <PhoneIcon />
+                        </InputFiled>
+                        <InputFiled
+                          placeholder="Address"
+                          testID="address"
+                          onChangeText={onHandleChange('address')}
+                          defaultValue={animation.address}
+                          secureTextEntry={true}
+                          returnKeyType="done"
+                          activeColor={colors.BG_LIGHT_COLOR}
+                          style={{ borderRadius: 5 }}
+                        >
+                          <Entypo name="address" size={20} />
+                        </InputFiled>
+                      </AnimatedOptionContainerFooter>
+                    </AnimatedOptionContainer>
+                  </AccountSettingContainer>
+                  <Button
+                    title="update"
+                    buttonStyle={{
+                      backgroundColor: colors.FLOATING_MESSAGE_COLOR,
+                      marginTop: 20
+                    }}
+                    textStyle={{
+                      color: colors.BG_LIGHT_COLOR,
+                      fontFamily: fonts.IBM_SANS_BOLD
+                    }}
+                    onPress={handleSubmit}
+                  />
+                </ScrollViewContainer>
+              </Container>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </TouchableWithoutFeedback>
+    </Fragment>
   );
 }
 

--- a/src/screens/profile/styles.ts
+++ b/src/screens/profile/styles.ts
@@ -1,15 +1,141 @@
 import styled from 'styled-components/native';
+import Constants from 'expo-constants';
+import applyScale from '../../utils/applyScale';
 
 export const Container = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
   background-color: ${({ theme }) => theme.colors.BD_DARK_COLOR};
+  padding: 20px;
 `;
 
-export const Welcome = styled.Text`
-  font-size: ${({ theme }) => theme.fonts.LARGE_SIZE}px;
-  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+export const StatusBar = styled.View`
+  height: ${Constants.statusBarHeight}px;
+  background-color: ${({ theme }) => theme.colors.BG_LIGHT_COLOR};
+`;
+
+export const HeaderContainer = styled.View`
+  width: 100%;
+  height: ${applyScale(300)}px;
+  justify-content: space-evenly;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.BG_LIGHT_COLOR};
+`;
+
+export const ProfileImageContainer = styled.TouchableOpacity`
+  height: ${applyScale(120)}px;
+  width: ${applyScale(120)}px;
+  justify-content: center;
+  align-items: center;
+  border-radius: ${120 / 2}px;
+`;
+
+export const IconContainer = styled.TouchableOpacity`
+  height: ${applyScale(40)}px;
+  width: ${applyScale(40)}px;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.GRADIENT_COLOR_FROM};
+`;
+
+export const ProfileDetailsContainer = styled.View`
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  bottom: 25px;
+`;
+
+export const ProfileRecordsContainer = styled.View`
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  position: absolute;
+  bottom: 5px;
+`;
+
+export const ProfileResultsContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+`;
+
+export const RecordsTitle = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 2}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_REGULAR};
   color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
   text-transform: capitalize;
+  opacity: 0.3;
+`;
+
+export const RecordsResult = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 5}px;
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+  opacity: 0.8;
+`;
+
+export const UserName = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 5}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+  text-transform: capitalize;
+`;
+
+export const UserEmail = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 3}px;
+  font-family: ${({ theme }) => theme.fonts.MONTSERRAT_SEMI_BOLD};
+  opacity: 0.3;
+  padding: 5px;
+`;
+
+export const ScrollViewContainer = styled.View`
+  flex: 1;
+  width: 100%;
+`;
+
+export const AccountSettingTitle = styled.Text`
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 5}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+  opacity: 0.2;
+  text-transform: uppercase;
+`;
+
+export const AccountSettingContainer = styled.View`
+  margin-top: 15px;
+  border-radius: 5px;
+  background-color: ${({ theme }) => theme.colors.BG_LIGHT_COLOR};
+`;
+
+export const OptionContainer = styled.View`
+  height: ${applyScale(150)}px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0px 15px;
+`;
+
+export const OptionTitle = styled.Text`
+  flex: 1;
+  font-size: ${({ theme }) => theme.fonts.MEDIUM_SIZE + 3}px;
+  font-family: ${({ theme }) => theme.fonts.IBM_SANS_BOLD};
+  color: ${({ theme }) => theme.colors.FONT_DARK_COLOR};
+  text-transform: capitalize;
+  opacity: 0.4;
+  margin-left: 20px;
+`;
+
+export const OptionContainerHeader = styled.TouchableOpacity`
+  height: ${applyScale(70)}px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const OptionContainerFooter = styled.View`
+  flex: 1;
+  width: 100%;
+  align-items: center;
 `;

--- a/src/utils/boxShadows.ts
+++ b/src/utils/boxShadows.ts
@@ -12,20 +12,17 @@ interface BoxShadowInterface {
 function createBoxShadowStyle({
   elevation,
   color,
-  opacity,
-  radius,
-  width,
-  height
+  opacity = 0.4,
+  radius = Math.floor((0.8 * elevation) / 2),
+  width = 0,
+  height = 0.5 * elevation
 }: BoxShadowInterface) {
   return {
     elevation,
     shadowColor: color,
-    shadowOffset: {
-      width: width || 0,
-      height: height || 0.5 * elevation
-    },
-    shadowOpacity: opacity || 0.4,
-    shadowRadius: radius || Math.floor((0.8 * elevation) / 2)
+    shadowOffset: { width, height },
+    shadowOpacity: opacity,
+    shadowRadius: radius
   };
 }
 


### PR DESCRIPTION
#### What does this PR do?

Have an overview feature of the app displayed in get started screen.

#### Description of Task to be completed?

Have the get started screen show the following:

1. Slider to show a brief description of core features of the app.
2. A slider pagination to show current slide position.
3. A get started button that leads to the sign up screen
4. A login button that leads to login screen

#### How should this be manually tested?

After cloning the repo,
`CD` into it and `RUN`

javascript
git checkout ft-get-started-screen

git pull origin ft-get-started-screen

yarn install

yarn test

Using an emulator: Launch the app, immediately after the splash screen you should see the get started screen.

#### Screenshots (if appropriate)

![Simulator Screen Shot - iPhone Xs - 2020-02-24 at 09 56 16](https://user-images.githubusercontent.com/12932317/75139025-e9eabd80-56eb-11ea-944f-93bec2b9e9d1.png)
